### PR TITLE
Fixes RT#90672

### DIFF
--- a/lib/Graphics/Primitive/Driver/Cairo.pm
+++ b/lib/Graphics/Primitive/Driver/Cairo.pm
@@ -14,13 +14,13 @@ use Math::Trig ':pi';
 
 with 'Graphics::Primitive::Driver';
 
-enum 'Graphics::Primitive::Driver::Cairo::AntialiasModes' => (
+enum 'Graphics::Primitive::Driver::Cairo::AntialiasModes' => [
     qw(default none gray subpixel)
-);
+];
 
-enum 'Graphics::Primitive::Driver::Cairo::Format' => (
+enum 'Graphics::Primitive::Driver::Cairo::Format' => [
     qw(PDF PS PNG SVG pdf ps png svg)
-);
+];
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This fixes RT#90672: warnings produced by the change to the way enum should be called.

See https://rt.cpan.org/Ticket/Display.html?id=90672
